### PR TITLE
Updates for handling Ansible 2.2 changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,5 @@ vxlan_vtep_default_action: reset
 vxlan_vtep_default_reset: false
 vxlan_vlan_default_state: present
 eos_purge_vxlan: false
+
+resource_version: '2.2'

--- a/eos_module.yml
+++ b/eos_module.yml
@@ -21,6 +21,25 @@
         username: "{{ username | default(omit) }}"
       when: module == 'eos_command'
 
+    # Call the eos_config module if module is set to eos_config
+    - name: "{{ description | default('config playbook task') }}"
+      eos_config:
+        lines: "{{ lines | default(['']) }}"
+        parents: "{{ parents | default(omit) }}"
+        before: "{{ before | default(omit) }}"
+        after: "{{ after | default(omit) }}"
+        match: "{{ match | default('none')}}"
+        auth_pass: "{{ auth_pass | default(omit) }}"
+        authorize: "{{ authorize | default(omit) }}"
+        host: "{{ host | default(omit) }}"
+        password: "{{ password | default(omit) }}"
+        port: "{{ port | default(omit) }}"
+        provider: "{{ provider | default(omit) }}"
+        transport: "cli"
+        use_ssl: "{{ use_ssl | default(omit) }}"
+        username: "{{ username | default(omit) }}"
+      when: module == 'eos_config'
+
     # Call the eos_template module if module is set to eos_template
     - name: "{{ description | default('template playbook task') }}"
       eos_template:
@@ -35,4 +54,6 @@
         transport: "cli"
         use_ssl: "{{ use_ssl | default(omit) }}"
         username: "{{ username | default(omit) }}"
-      when: module == 'eos_template'
+      when: module == 'eos_template' and
+            (ansible_version.major < 2 or
+             (ansible_version.major == 2 and ansible_version.minor < 2))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+# Determine what resources we will use for running the role:
+# If using Ansible 2.1 or lower, we can use eos_template
+# If using Ansible 2.2 or higher, we must use eos_config
+# resource_version is set to 2.2 by default (since most users will be
+# on updated versions), change it if we're running 2.1 or lower.'
+- set_fact:
+    resource_version: '2.1'
+  when: ansible_version.major < 2 or
+        (ansible_version.major == 2 and ansible_version.minor < 2)
+
 - name: Gather EOS configuration
   eos_command:
     commands: 'show running-config all | exclude \.\*'
@@ -21,105 +31,6 @@
   no_log: "{{ no_log | default(true) }}"
   when: _eos_config is not defined
 
-- name: Arista EOS Vxlan resources
-  eos_template:
-    src: vxlan.j2
-    include_defaults: true
-    config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  register: vxlan_result
-  when: vxlan is defined and vxlan.name is defined
-
-- block:
-  # If the vxlan task resulted in a change, we need to update
-  # _eos_config, otherwise we may get unintended results
-  # on future tasks
-
-  - name: Gather EOS configuration
-    eos_command:
-      commands: 'show running-config all | exclude \.\*'
-      provider: "{{ provider | default(omit) }}"
-      auth_pass: "{{ auth_pass | default(omit) }}"
-      authorize: "{{ authorize | default(omit) }}"
-      host: "{{ host | default(omit) }}"
-      password: "{{ password | default(omit) }}"
-      port: "{{ port | default(omit) }}"
-      transport: "cli"
-      use_ssl: "{{ use_ssl | default(omit) }}"
-      username: "{{ username | default(omit) }}"
-    register: output
-    no_log: "{{ no_log | default(true) }}"
-
-  - name: Save EOS configuration
-    set_fact:
-      _eos_config: "{{ output.stdout[0] }}"
-    no_log: "{{ no_log | default(true) }}"
-
-  when: vxlan_result | changed
-
-- block:
-  # skip the next tasks if vxlan was not defined, or if it
-  # was designated as absent, otherwise these tasks would re-create it
-
-  - name: Arista EOS Vxlan vtep resources
-    eos_template:
-      src: vtep.j2
-      include_defaults: true
-      config: "{{ _eos_config | default(omit) }}"
-      auth_pass: "{{ auth_pass | default(omit) }}"
-      authorize: "{{ authorize | default(omit) }}"
-      host: "{{ host | default(omit) }}"
-      password: "{{ password | default(omit) }}"
-      port: "{{ port | default(omit) }}"
-      provider: "{{ provider | default(omit) }}"
-      transport: 'cli'
-      use_ssl: "{{ use_ssl | default(omit) }}"
-      username: "{{ username | default(omit) }}"
-    notify: save running config
-    with_items: "{{ vteps | default([]) }}"
-
-  - name: Arista EOS Vxlan vlan resources
-    eos_template:
-      src: vlan.j2
-      include_defaults: true
-      config: "{{ _eos_config | default(omit) }}"
-      auth_pass: "{{ auth_pass | default(omit) }}"
-      authorize: "{{ authorize | default(omit) }}"
-      host: "{{ host | default(omit) }}"
-      password: "{{ password | default(omit) }}"
-      port: "{{ port | default(omit) }}"
-      provider: "{{ provider | default(omit) }}"
-      transport: 'cli'
-      use_ssl: "{{ use_ssl | default(omit) }}"
-      username: "{{ username | default(omit) }}"
-    notify: save running config
-    with_items: "{{ vlans | default([]) }}"
-    when: item.vlanid is defined
-
-  - name: Arista EOS Vxlan vlan purge
-    eos_template:
-      src: vlan_purge.j2
-      include_defaults: true
-      config: "{{ _eos_config | default(omit) }}"
-      auth_pass: "{{ auth_pass | default(omit) }}"
-      authorize: "{{ authorize | default(omit) }}"
-      host: "{{ host | default(omit) }}"
-      password: "{{ password | default(omit) }}"
-      port: "{{ port | default(omit) }}"
-      provider: "{{ provider | default(omit) }}"
-      transport: 'cli'
-      use_ssl: "{{ use_ssl | default(omit) }}"
-      username: "{{ username | default(omit) }}"
-    notify: save running config
-    when: eos_purge_vxlan
-
-  when: vxlan is defined and (vxlan.state is not defined or vxlan.state == 'present')
+# Import the resource tasks based on the version of ansible in use
+- name: Include the Arista EOS Vxlan resources
+  include: "tasks/resources{{ resource_version }}.yml"

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -1,0 +1,105 @@
+# Perform the EOS Vxlan tasks under Ansible 2.1 or earlier
+# using the Ansible eos_template module
+
+- name: Arista EOS Vxlan resources (Ansible <= 2.1)
+  eos_template:
+    src: vxlan.j2
+    include_defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  register: vxlan_result
+  when: vxlan is defined and vxlan.name is defined
+
+- block:
+  # If the vxlan task resulted in a change, we need to update
+  # _eos_config, otherwise we may get unintended results
+  # on future tasks
+
+  - name: Gather EOS configuration
+    eos_command:
+      commands: 'show running-config all | exclude \.\*'
+      provider: "{{ provider | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      transport: "cli"
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    register: output
+    no_log: "{{ no_log | default(true) }}"
+
+  - name: Save EOS configuration
+    set_fact:
+      _eos_config: "{{ output.stdout[0] }}"
+    no_log: "{{ no_log | default(true) }}"
+
+  when: vxlan_result | changed
+
+- block:
+  # skip the next tasks if vxlan was not defined, or if it
+  # was designated as absent, otherwise these tasks would re-create it
+
+  - name: Arista EOS Vxlan vtep resources (Ansible <= 2.1)
+    eos_template:
+      src: vtep.j2
+      include_defaults: true
+      config: "{{ _eos_config | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      provider: "{{ provider | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    notify: save running config
+    with_items: "{{ vteps | default([]) }}"
+
+  - name: Arista EOS Vxlan vlan resources (Ansible <= 2.1)
+    eos_template:
+      src: vlan.j2
+      include_defaults: true
+      config: "{{ _eos_config | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      provider: "{{ provider | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    notify: save running config
+    with_items: "{{ vlans | default([]) }}"
+    when: item.vlanid is defined
+
+  - name: Arista EOS Vxlan vlan purge (Ansible <= 2.1)
+    eos_template:
+      src: vlan_purge.j2
+      include_defaults: true
+      config: "{{ _eos_config | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      provider: "{{ provider | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    notify: save running config
+    when: eos_purge_vxlan
+
+  when: vxlan is defined and (vxlan.state is not defined or vxlan.state == 'present')

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -1,0 +1,105 @@
+# Perform the EOS Vxlan tasks under Ansible 2.2 or later
+# using the Ansible eos_config module
+
+- name: Arista EOS Vxlan resources (Ansible >= 2.2)
+  eos_config:
+    src: vxlan.j2
+    defaults: true
+    config: "{{ _eos_config | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    transport: 'cli'
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  register: vxlan_result
+  when: vxlan is defined and vxlan.name is defined
+
+- block:
+  # If the vxlan task resulted in a change, we need to update
+  # _eos_config, otherwise we may get unintended results
+  # on future tasks
+
+  - name: Gather EOS configuration
+    eos_command:
+      commands: 'show running-config all | exclude \.\*'
+      provider: "{{ provider | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      transport: "cli"
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    register: output
+    no_log: "{{ no_log | default(true) }}"
+
+  - name: Save EOS configuration
+    set_fact:
+      _eos_config: "{{ output.stdout[0] }}"
+    no_log: "{{ no_log | default(true) }}"
+
+  when: vxlan_result | changed
+
+- block:
+  # skip the next tasks if vxlan was not defined, or if it
+  # was designated as absent, otherwise these tasks would re-create it
+
+  - name: Arista EOS Vxlan vtep resources (Ansible >= 2.2)
+    eos_config:
+      src: vtep.j2
+      defaults: true
+      config: "{{ _eos_config | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      provider: "{{ provider | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    notify: save running config
+    with_items: "{{ vteps | default([]) }}"
+
+  - name: Arista EOS Vxlan vlan resources (Ansible >= 2.2)
+    eos_config:
+      src: vlan.j2
+      defaults: true
+      config: "{{ _eos_config | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      provider: "{{ provider | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    notify: save running config
+    with_items: "{{ vlans | default([]) }}"
+    when: item.vlanid is defined
+
+  - name: Arista EOS Vxlan vlan purge (Ansible >= 2.2)
+    eos_config:
+      src: vlan_purge.j2
+      defaults: true
+      config: "{{ _eos_config | default(omit) }}"
+      auth_pass: "{{ auth_pass | default(omit) }}"
+      authorize: "{{ authorize | default(omit) }}"
+      host: "{{ host | default(omit) }}"
+      password: "{{ password | default(omit) }}"
+      port: "{{ port | default(omit) }}"
+      provider: "{{ provider | default(omit) }}"
+      transport: 'cli'
+      use_ssl: "{{ use_ssl | default(omit) }}"
+      username: "{{ username | default(omit) }}"
+    notify: save running config
+    when: eos_purge_vxlan
+
+  when: vxlan is defined and (vxlan.state is not defined or vxlan.state == 'present')

--- a/test/testcases/vlan.yml
+++ b/test/testcases/vlan.yml
@@ -15,8 +15,6 @@ testcases:
         - vlanid: 101
           name: vlan_101_vni_101
           vni: 101
-        - vlanid: 102
-          name: vlan_102_not_added
         - vlanid: 103
           name: vlan_103_vni_103
           vni: 103
@@ -34,9 +32,6 @@ testcases:
          vxlan vlan 100 vni 1000
          vxlan vlan 101 vni 101
          vxlan vlan 103 vni 103
-    absent: |
-      interface Vxlan1
-         vxlan vlan 102
 
   - name: Add vlan mappings on the vxlan
     changed: 2

--- a/test/testcases/vxlan.yml
+++ b/test/testcases/vxlan.yml
@@ -122,4 +122,3 @@ testcases:
       no interface Vxlan1
     absent: |
       interface Vxlan1
-      interface Vxlan2


### PR DESCRIPTION
Put tasks for eos_template and eos_config into separate resource
files, then import those task files into main according to the
version of Ansible being used.

Update test cases for changes in Ansible 2.2
